### PR TITLE
Allow to deploy notaints controllers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ k0s_libexec_dir: /usr/libexec/k0s
 k0s_direct_download: false
 
 k0s_worker_on_controller: false
+k0s_no_taints: false
 
 k0s_force: false
 k0s_debug: false

--- a/library/k0s_install.py
+++ b/library/k0s_install.py
@@ -31,6 +31,7 @@ class K0sInstall(object):
         self.config = module.params.get("config")
         self.data_dir = module.params.get("data_dir")
         self.enable_worker = module.params.get("enable_worker")
+        self.no_taints = module.params.get("no_taints")
         self.token_file = module.params.get("token_file")
         self.arguments = module.params.get("arguments")
 
@@ -46,6 +47,7 @@ class K0sInstall(object):
         module.log(msg=f" config            : {self.config}")
         module.log(msg=f" data_dir          : {self.data_dir}")
         module.log(msg=f" enable_worker     : {self.enable_worker}")
+        module.log(msg=f" no_taints         : {self.no_taints}")
         module.log(msg=f" token_file        : {self.token_file}")
         module.log(msg=f" arguments         : {self.arguments}")
         module.log(msg="----------------------------")
@@ -117,6 +119,9 @@ class K0sInstall(object):
 
         if self.state in ["initial-controller", "controller"] and self.enable_worker:
             args.append("--enable-worker")
+
+        if self.state in ["initial-controller", "controller"] and self.no_taints:
+            args.append("--no-taints")
 
         if self.config is not None and os.path.isfile(self.config):
             args.append("--config")
@@ -230,6 +235,11 @@ def main():
             type='str'
         ),
         enable_worker=dict(
+            required=False,
+            default=False,
+            type=bool
+        ),
+        no_taints=dict(
             required=False,
             default=False,
             type=bool

--- a/tasks/configure/initial_controller.yml
+++ b/tasks/configure/initial_controller.yml
@@ -29,6 +29,7 @@
     config: "{{ k0s_config_dir }}/k0s.yaml"
     data_dir: "{{ k0s_data_dir }}"
     enable_worker: "{{ k0s_worker_on_controller | bool }}"
+    no_taints: "{{ k0s_no_taints | bool }}"
     arguments: "{{ k0s_extra_arguments.controller | default([]) + k0s_extra_args | default([]) }}"
   notify:
     - daemon-reload


### PR DESCRIPTION
Add k0s_no_taints argument as a trigger to deploy conrollers with disabled taints